### PR TITLE
Conflict between webpack and import-loader resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ window.config = {
 ```
 
 ## How to setup sunbird-generic-editor in local
-1. Clone this sunbird-generic-editor repo from [here](https://github.com/project-sunbird/sunbird-generic-editor) 
+1. Clone this sunbird-generic-editor repo from [here](https://github.com/project-sunbird/sunbird -generic-editor) 
 2. Clone the sunbird-content-plugins repo from [here](https://github.com/project-sunbird/sunbird-content-plugins) 
 3. Go to the root directory sunbird-generic-editor.
 4. Run `npm install` to install node modules.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ window.config = {
 
 ## ChangeLogs
    For changes logs please refer [here](https://github.com/project-sunbird/sunbird-generic-editor/releases) 
-
   
  >For sunbird-generic-editor demo please visit [here](https://staging.open-sunbird.org/workspace/content/create)   
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ window.config = {
 
 
 ## ChangeLogs
-   For changes logs please refer [here](https://github.com/project-sunbird/sunbird-generic  -editor/releases) 
+   For changes logs please refer [here](https://github.com/project-sunbird/sunbird-generic-editor/releases) 
 
   
  >For sunbird-generic-editor demo please visit [here](https://staging.open-sunbird.org/workspace/content/create)   

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ window.config = {
 1. Clone this sunbird-generic-editor repo from [here](https://github.com/project-sunbird/sunbird-generic-editor) 
 2. Clone the sunbird-content-plugins repo from [here](https://github.com/project-sunbird/sunbird-content-plugins) 
 3. Go to the root directory sunbird-generic-editor.
-4. Run `npm install` to install node modules.
+4. Run `yarn install` to install node modules.
 5. `cd app` and run `bower install` to install bower components
 6. Create a symlink to 'sunbird-content-plugins' (`ln -s ../sunbird-content-plugins plugins`)
 >On Windows: use `mklink`

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ window.config = {
 ## How to setup sunbird-generic-editor in local
 1. Clone this sunbird-generic-editor repo from [here](https://github.com/project-sunbird/sunbird-generic-editor) 
 2. Clone the sunbird-content-plugins repo from [here](https://github.com/project-sunbird/sunbird-content-plugins) 
-3. Go to the root directory sunbird-generic-editor.
+3. Go to the root directory of sunbird-generic-editor.
 4. Run `npm install` to install node modules.
 5. `cd app` and run `bower install` to install bower components
 6. Create a symlink to 'sunbird-content-plugins' (`ln -s ../sunbird-content-plugins plugins`)

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ window.config = {
 1. Clone this sunbird-generic-editor repo from [here](https://github.com/project-sunbird/sunbird -generic-editor) 
 2. Clone the sunbird-content-plugins repo from [here](https://github.com/project-sunbird/sunbird-content-plugins) 
 3. Go to the root directory of sunbird-generic-editor.
-4. Run `npm install` to install node modules.
+4. Run `yarn install` to install node modules.
 5. `cd app` and run `bower install` to install bower components
 6. Create a symlink to 'sunbird-content-plugins' (`ln -s ../sunbird-content-plugins plugins`)
 >On Windows: use `mklink`

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ window.config = {
 1. Clone this sunbird-generic-editor repo from [here](https://github.com/project-sunbird/sunbird -generic-editor) 
 2. Clone the sunbird-content-plugins repo from [here](https://github.com/project-sunbird/sunbird-content-plugins) 
 3. Go to the root directory of sunbird-generic-editor.
-4. Run `yarn install` to install node modules.
+4. Run `npm install` to install node modules.
 5. `cd app` and run `bower install` to install bower components
 6. Create a symlink to 'sunbird-content-plugins' (`ln -s ../sunbird-content-plugins plugins`)
 >On Windows: use `mklink`


### PR DESCRIPTION
This is in reference to the issue created on Jira: https://project-sunbird.atlassian.net/browse/KN-887?atlOrigin=eyJpIjoiMjBlN2QyMjE4NTBjNDMwM2FjMTQ2ODllMTU1OWYyZTQiLCJwIjoiaiJ9
The conflict is resolved as 'npm install' was unable to resolve dependency tree. 
The solution contains installing it with 'yarn'.