### PR TITLE
Add Dependabot configuration and dependency submission workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+version: 2
+updates:
+  # Root package.json — main editor source and build tooling
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"        # 30 min after dependency-submission workflow (03:00 UTC)
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      gulp-tools:
+        patterns:
+          - "gulp*"
+          - "grunt*"
+      webpack-tools:
+        patterns:
+          - "webpack*"
+          - "*-loader"
+          - "clean-webpack-plugin"
+          - "copy-webpack-plugin"
+          - "html-webpack-plugin"
+          - "mini-css-extract-plugin"
+          - "css-minimizer-webpack-plugin"
+          - "zip-webpack-plugin"
+      karma-testing:
+        patterns:
+          - "karma*"
+          - "jasmine*"
+      eslint:
+        patterns:
+          - "eslint*"
+
+  # deploy/ has its own package.json with gulp deployment tooling
+  - package-ecosystem: "npm"
+    directory: "/deploy"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      gulp-tools:
+        patterns:
+          - "gulp*"
+
+  # Keep GitHub Actions workflow action versions updated
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,50 @@
+name: Dependency Submission
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'          # 03:00 UTC every Monday — runs before Dependabot (03:30)
+  push:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'deploy/package.json'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'deploy/package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit-npm-root:
+    name: Submit npm (root)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  submit-npm-deploy:
+    name: Submit npm (deploy/)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      # No lock file in deploy/ — generate one without installing node_modules
+      - run: npm install --package-lock-only
+        working-directory: deploy
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./deploy


### PR DESCRIPTION
Summary
                                                                                                                                                                                      
  - Enables automated weekly dependency updates for npm packages (root and deploy/) and GitHub Actions via Dependabot, reducing manual effort in keeping dependencies current and     
  patched.
  - Adds a dependency submission workflow to populate the GitHub Dependency Graph, which Dependabot requires to detect vulnerabilities in transitive dependencies.                    
  - Dependencies are grouped by toolchain area (gulp, webpack, karma, eslint) to reduce PR noise from related batch upgrades.                                                         
                                                                                                                                                                                      
  Changes                                                                                                                                                                             
                                                                                                                                                                                      
  - Add .github/dependabot.yml — configures three Dependabot update targets: npm root (/), npm deploy (/deploy), and github-actions, all on a weekly Monday schedule at 03:30 UTC.    
  Defines grouping rules for gulp, webpack, karma/jasmine, and eslint packages.
  - Add .github/workflows/dependency-submission.yml — GitHub Actions workflow that submits npm dependency graphs for both root and deploy/ package manifests to the GitHub Dependency 
  Graph. Runs on a Monday cron (03:00 UTC, before Dependabot) and on pushes/PRs to master that touch lockfiles.                                                                       
  
  How to Test                                                                                                                                                                         
                                                         
  1. Merge this PR to master.                                                                                                                                                         
  2. Navigate to Settings → Security → Code security and analysis on GitHub and verify "Dependency graph" shows entries for both package.json and deploy/package.json.
  3. Check Actions → Dependency Submission — the workflow should trigger on merge and complete successfully.                                                                          
  4. On the next Monday (or via manual workflow_dispatch), confirm Dependabot opens PRs grouped by the defined toolchain categories.                                                  
  5. Run gh workflow run dependency-submission.yml to trigger it manually and verify both jobs (Submit npm (root) and Submit npm (deploy/)) succeed.                                  
                                                                                                                                                                                      
  Checklist                                                                                                                                                                           
                                                                                                                                                                                      
  - Tests added or updated                                                                                                                                                            
  - Documentation updated (if public API or behavior changed)
  - No breaking changes — or breaking changes noted with ! in title and explained in Summary                                                                                          
  - Reviewed my own diff before requesting review                                                                                                                                     
                                                                                                                                                                                      
  ---